### PR TITLE
Add material color rounding functionality

### DIFF
--- a/src/routers/octoprint.router.ts
+++ b/src/routers/octoprint.router.ts
@@ -87,11 +87,25 @@ export default function oceanPrintRoute(): FastifyPluginAsync {
 
 			// Ensure the material is valid
 			const printerMaterials = await PrinterService.getAllMaterials();
-			const isValidMaterials = printerMaterials.some((printerMaterial) =>
-				MaterialUtility.compareMaterials(printerMaterial, metadata.materials),
+			let roundedMaterials = MaterialUtility.roundMaterials(
+				metadata.materials,
+				printerMaterials.flat(),
+			);
+			// Ensure none of the materials are null
+			if (roundedMaterials.some((material) => material === null)) {
+				throw errors.incompatibleMaterialsError(
+					"One or more materials do not exist",
+				);
+			}
+			// Ensure the materials are compatible with some printer
+			const isValidMaterials = MaterialUtility.compareMaterialsList(
+				printerMaterials,
+				roundedMaterials as { type: string; color: string }[],
 			);
 			if (!isValidMaterials) {
-				throw errors.incompatibleMaterialsError();
+				throw errors.incompatibleMaterialsError(
+					"The selected materials are not compatible with any printer",
+				);
 			}
 
 			// Save the file to the data directory
@@ -140,7 +154,13 @@ export default function oceanPrintRoute(): FastifyPluginAsync {
 						file: fileName,
 						printerModel: metadata.printerModel,
 						printTime: metadata.printTime,
-						materials: metadata.materials,
+						materials: roundedMaterials as {
+							id: number;
+							type: string;
+							color: string;
+							name: string;
+							usage: number;
+						}[],
 					},
 				},
 			});

--- a/src/services/printer.service.ts
+++ b/src/services/printer.service.ts
@@ -170,7 +170,7 @@ export async function setCleared(printerId: number, isSuccessful: boolean) {
 }
 
 /**
- *
+ * Get all materials from all printers as a list of materials per printer.
  * @returns
  */
 export async function getAllMaterials() {
@@ -180,6 +180,15 @@ export async function getAllMaterials() {
 		},
 	});
 	return printers.map((printer) => printer.materials);
+}
+
+/**
+ * Get all materials from all printers as a single list.
+ * @returns
+ */
+export async function getAllMaterialsFlat() {
+	let materials = await getAllMaterials();
+	return materials.flat();
 }
 
 /**


### PR DESCRIPTION
Instead of only assigning colored print jobs based on which printer contains the visibly closest color, the system first rounds print job colors to the closest existing color and then makes assignments.